### PR TITLE
Fix auto-transpose

### DIFF
--- a/pitch/auto-transpose/module.ily
+++ b/pitch/auto-transpose/module.ily
@@ -1,4 +1,4 @@
-\version "2.18.2"
+\version "2.19.7"
 
 \header {
   snippet-title = "auto-transpose"
@@ -44,7 +44,7 @@ autoTransposeEngraver =
        (let ((mcp (ly:context-property context 'music-concert-pitch)) ; music is in concert-pitch t/f
               (pcp (ly:context-property context 'print-concert-pitch)) ; print it in concert-pitch t/f
               (transp (ly:context-property context 'instrumentTransposition)) ; instrument transposition
-              (keysig (ly:context-property context 'keySignature)) ; key-signature
+              (keysig (ly:context-property context 'keyAlterations)) ; key-signature
               (tonic (ly:context-property context 'tonic))) ; key-signature tonic
 
          (define (do-transp m)
@@ -67,7 +67,7 @@ autoTransposeEngraver =
                  (if (ly:pitch? ap)
                      (begin
                      (ly:music-transpose m (ly:pitch-diff base tp))
-                     ))) % TODO
+                     ))) ; TODO
              (ly:music-set-property! m 'auto-transpose tp)
              ))
 


### PR DESCRIPTION
Within a scheme section in pitch/auto-transpose/module.ily was comment started by '%' instead of ';' which apparently was accepted (although probably not acceptably) by older lilypond versions. Sufficiently current versions just choke on the input, unfortunately without giving much assistance 

While looking for the error, I ran convert-ly in case the problem was due to some recent syntax change. The keySignature -> keyAlterations change suggested happened such a long time (and multiple stable releases) ago, I saw no reason to not just make that change as well.