### PR TITLE
auto-transpose: added automatic key signatures

### DIFF
--- a/pitch/auto-transpose/README.md
+++ b/pitch/auto-transpose/README.md
@@ -9,8 +9,9 @@ The first one is a standard lilypond-context-property, which is used to set inst
 So the following displays a C major scale, which sounds like a B flat major scale, if played by an instrument tuned in B flat, like trumpet.
 
 ```
-\version "2.18.2"
-\include "editorial-tools/auto-transpose/definitions.ily"
+\version "2.20.0"
+\include "oll-core/package.ily"
+\loadModule oll-misc.pitch.auto-transpose
 
 \new Staff \with {
  \autoTranspose
@@ -21,7 +22,11 @@ So the following displays a C major scale, which sounds like a B flat major scal
 }
 ```
 
-If the instrument is switched, the auto-transpose will follow.
+If the instrument is switched, the auto-transpose will follow, and the key signature will be reprinted automatically. The inserted key signatures are printed by a separate engraver.
+
+Known issue:
+
+* If a key change happens at the same moment as a transposition change, printing the correct key signature depends on the order in which the Lilypond commands are written. See the examples in auto-transpose-keys-1.ly and auto-transpose-keys-2.ly for details.
 
 There are some TODOs:
 
@@ -31,5 +36,5 @@ There are some TODOs:
 	2. transpose from concert to instrument pitch
 	3. transpose from instrument to concert pitch
     This might also be an initial parameter for the engraver, so we needn't define extra context-properties
-* TBC
+* Improve the key signature behavior when key changes happen simultaneously with transposition changes. This may not be possible without a patch to Lilypond itself.
 

--- a/pitch/auto-transpose/README.md
+++ b/pitch/auto-transpose/README.md
@@ -1,15 +1,14 @@
 The auto-transpose engraver can be used to automatically transpose music according to the instrument transposition. The engraver has to know, if the music it finds in this context is in concert- or in instrument-pitch. Then it can use the `instrumentTransposition`, which is set by the `\transposition` command, to transpose the music as necessary.
 
-The engraver looks for three context-properties:
+The engraver looks for two context-properties:
 1. instrumentTransposition
-2. music-concert-pitch
-3. print-concert-pitch
+2. transposeDirection
 
-The first one is a standard lilypond-context-property, which is used to set instrument transposition for MIDI-output. So, if you use for example `\transposition bes` -- e.g. trumpet or clarinet -- MIDI-output will sound one note lower. Now the other two context-properties are used to set, if the music is provided in concert-pitch and if it shall be printed in concert-pitch. If the music is given in concert pitch and shall be printed in instrument pitch, the engraver transposes it accordingly. `\autoTranspose` provides a context-mod which consists the engraver and sets the *-concert-pitch variables to display concert-pitched music in instrument pitch.
+The first one is a standard lilypond-context-property, which is used to set instrument transposition for MIDI-output. So, if you use for example `\transposition bes` -- e.g. trumpet or clarinet -- MIDI-output will sound one note lower. The other context-property is used to set if the music is provided in concert-pitch and printed in instrument pitch, or vica versa. If the music is given in concert pitch and shall be printed in instrument pitch, the engraver transposes it accordingly. `\autoTranspose` provides a context-mod which consists the engraver and sets transposeDirection to display concert-pitched music in instrument pitch.
 So the following displays a C major scale, which sounds like a B flat major scale, if played by an instrument tuned in B flat, like trumpet.
 
 ```
-\version "2.20.0"
+\version "2.24.0"
 \include "oll-core/package.ily"
 \loadModule oll-misc.pitch.auto-transpose
 
@@ -22,19 +21,13 @@ So the following displays a C major scale, which sounds like a B flat major scal
 }
 ```
 
-If the instrument is switched, the auto-transpose will follow, and the key signature will be reprinted automatically. The inserted key signatures are printed by a separate engraver.
+If the instrument is switched, the auto-transpose will follow, and the key signature will be reprinted automatically.
 
 Known issue:
 
-* If a key change happens at the same moment as a transposition change, printing the correct key signature depends on the order in which the Lilypond commands are written. See the examples in auto-transpose-keys-1.ly and auto-transpose-keys-2.ly for details.
+* If a key change happens at the same moment as a transposition change, a warning may be triggered ``warning: conflict with event: `key-change-event'``. These can be safely ignored.
 
 There are some TODOs:
 
 * If the music is given in instrument pitch and shall be displayed, the `instrumentTransposition` property still has to be set, but that leads to incorrect MIDI-pitch.
-* We only need one context-property beside `instrumentTransposition`, which says:
-    1. do nothing
-	2. transpose from concert to instrument pitch
-	3. transpose from instrument to concert pitch
-    This might also be an initial parameter for the engraver, so we needn't define extra context-properties
-* Improve the key signature behavior when key changes happen simultaneously with transposition changes. This may not be possible without a patch to Lilypond itself.
 

--- a/pitch/auto-transpose/README.md
+++ b/pitch/auto-transpose/README.md
@@ -8,11 +8,11 @@ For example, this snippet is a B-flat major scale written in Lilypond at concert
 \loadModule oll-misc.pitch.auto-transpose
 
 \new Staff \with {
- \autoTranspose
+  \autoTranspose
 } \relative c'' {
-   \transposition bes
-   \key bes \major
-   bes4 a g f ees d c bes
+  \transposition bes
+  \key bes \major
+  bes4 a g f ees d c bes
 }
 ```
 
@@ -20,7 +20,7 @@ The engraver looks for three context-properties:
 
 1. `instrumentTransposition`
 2. `transposeDirection`
-3. `autoInsertKeySignatures`
+3. `autoTransposeKeySignatures`
 
 `instrumentTransposition` is a standard Lilypond context property, set by the `\transposition` command. Lilypond uses it to output correct MIDI pitch when music is entered at instrument pitch. Auto-transpose engraver uses this property to transpose the printed music.
 
@@ -32,20 +32,38 @@ For example, this snippet is a concert B-flat major scale entered into Lilypond 
 
 ```
 \new Staff \with {
- \consists \autoTransposeEngraver
+  \consists \autoTransposeEngraver
   transposeDirection = #'pitch-to-concert
 } \relative c'' {
-   \transposition bes
-   \key c \major
-   c4 b a g f e d c
+  \transposition bes
+  \key c \major
+  c4 b a g f e d c
 }
 ```
 
 If `transposeDirection` is set to `#f`, no automatic transposition will occur.
 
-If `instrumentTransposition` changes, as when a player switches instruments, auto-transpose will follow. By default, key signatures will be reprinted automatically whenever `instrumentTransposition` changes.
+If `instrumentTransposition` changes, as when a player switches instruments, auto-transpose will follow. 
 
-Automatically inserted key signatures can be turned off by setting `autoInsertKeySignatures` to `#f`. This behavior is equivalent to the old version of auto-transpose.
+If `autoTransposeKeySignatures` is set to `'insert-and-transpose`, key signatures will be reprinted automatically whenever `instrumentTransposition` changes. This is the default.
+
+If `autoTransposeKeySignatures` is set to `'transpose-only`, key signatures will not be automatically inserted, but explicit key changes will still be transposed. This is similar to the old version of auto-transpose.
+
+If `autoTransposeKeySignatures` is set to `#f`, auto-transpose will ignore key signatures. Use this setting any time you would `\remove Key_engraver` or `\omit KeySignature`, such as for atonal passages or transposing instruments that traditionally do not use a key signature, such as orchestral horns. 
+
+In this example, the concert B-flat major scale is printed at instrument pitch for horn, with no key signature. Note that if `autoTransposeKeySignatures = ##f` had not been set, the B-flat accidental would not be printed due to auto-transpose behaving as if the key signature were present.
+
+```
+\new Staff \with {
+  \consists \autoTransposeEngraver
+  autoTransposeKeySignatures = ##f
+  \remove Key_engraver
+} \relative c'' {
+  \transposition f
+  \key bes \major
+  bes4 a g f ees d c bes
+}
+```
 
 A context-mod `\autoTranspose` is provided, which enables the default behavior, equivalent to:
 

--- a/pitch/auto-transpose/README.md
+++ b/pitch/auto-transpose/README.md
@@ -23,6 +23,8 @@ So the following displays a C major scale, which sounds like a B flat major scal
 
 If the instrument is switched, the auto-transpose will follow, and the key signature will be reprinted automatically.
 
+A third context property `insertKeySignatures` is available to turn off the automatically inserted key signatures. Explicit key changes will still be transposed.
+
 Known issue:
 
 * If a key change happens at the same moment as a transposition change, a warning may be triggered ``warning: conflict with event: `key-change-event'``. These can be safely ignored.

--- a/pitch/auto-transpose/module.ily
+++ b/pitch/auto-transpose/module.ily
@@ -2,7 +2,7 @@
 
 \header {
   snippet-title = "auto-transpose"
-  snippet-author = "Jan-Peter Voigt"
+  snippet-author = "Jan-Peter Voigt, Saul James Tobin"
   snippet-description = \markup {
     \wordwrap {
       This engraver transposes music accordingly to 'instrumentTransposition'
@@ -35,72 +35,111 @@
 #(translator-property-description 'music-concert-pitch boolean? "music is in concert pitch")
 #(translator-property-description 'print-concert-pitch boolean? "print it in concert pitch")
 
+#(define (which-transp context transp)
+   (let ((base (ly:make-pitch 0 0 0)) ; pitch c'
+          (mcp (ly:context-property context 'music-concert-pitch)) ; music is in concert-pitch t/f
+          (pcp (ly:context-property context 'print-concert-pitch)) ; print it in concert-pitch t/f
+          )
+     (cond
+      ((and mcp (not pcp) (ly:pitch? transp))
+       (ly:pitch-diff base transp))
+      ((and (not mcp) pcp (ly:pitch? transp))
+       transp)
+      (else #f))))
+
+#(define (cond-transp context music)
+   (let ((transp (ly:context-property context 'instrumentTransposition))
+         (base (ly:make-pitch 0 0 0)))
+     (define (do-transp m)
+       (let ((ap (ly:music-property m 'auto-transpose))
+             (tp (which-transp context transp))
+             )
+         (if (ly:pitch? tp)
+             (cond
+              ((and (ly:pitch? ap)(not (equal? ap tp)))
+               (ly:music-transpose m (ly:pitch-diff tp ap)))
+              ((not (ly:pitch? ap))
+               (ly:music-transpose m tp))
+              )
+             (if (ly:pitch? ap)
+                 (begin
+                  (ly:music-transpose m (ly:pitch-diff base tp))
+                  ))) ; TODO
+         (ly:music-set-property! m 'auto-transpose tp)
+         ))
+     ; execute transposition
+     (do-transp music)
+     ))
+
+#(define (complete-keysig alterations)
+   (let ((cmaj '((0 . 0) (1 . 0) (2 . 0) (3 . 0) (4 . 0) (5 . 0) (6 . 0)))
+         (update (lambda (el sig) (assoc-set! sig (car el) (cdr el)))))
+     (fold update (copy-tree cmaj) alterations)))
+
+autoKeysigEngraver =
+#(lambda (context)
+   (let ((lasttransp (ly:context-property context 'instrumentTransposition)))
+     (define (insert-key)
+       (let* ((keysig (complete-keysig (ly:context-property context 'keyAlterations)))
+              (tonic (ly:context-property context 'tonic))
+              (transp (ly:context-property context 'instrumentTransposition))
+              (keysig-music (make-music 'KeyChangeEvent
+                              'pitch-alist keysig
+                              'tonic tonic
+                              'length (ly:make-moment 0)
+                              'auto-transpose (which-transp context lasttransp))))
+         (if (not (equal? transp lasttransp))
+             (let ((new-key (ly:music-deep-copy keysig-music)))
+               (cond-transp context new-key)
+               (if (not (equal? (ly:music-property keysig-music 'pitch-alist) ; don't reprint key if only 8ve change
+                                (ly:music-property new-key 'pitch-alist)))
+                   (let ((key-event (ly:make-stream-event
+                                     (ly:make-event-class 'key-change-event)
+                                     (ly:music-mutable-properties new-key))))
+                     (ly:message "Transposition changed. Inserting key signature in measure ~A."
+                       (ly:context-property context 'currentBarNumber))
+                     (ly:event-set-property! key-event 'music-cause new-key)
+                     (ly:broadcast (ly:context-event-source context) key-event)
+                     )))
+             (set! lasttransp transp))))
+     (define (already-key)
+       (let ((transp (ly:context-property context 'instrumentTransposition)))
+         (if (not (equal? transp lasttransp))
+             (set! lasttransp transp))))
+     (make-engraver
+      (listeners
+       ((note-event engraver event)
+        (insert-key))
+       ((rest-event engraver event)
+        (insert-key))
+       ((key-change-event engraver event)
+        (already-key))
+       )
+      )
+     )
+   )
+
 % engraver to automatically transpose music
 autoTransposeEngraver =
 #(lambda (context)
-   (let ((base (ly:make-pitch 0 0 0)) ; pitch c'
-          (lasttransp (ly:context-property context 'instrumentTransposition))) ; last instrument transposition
-     (define (cond-transp engraver music)
-       (let ((mcp (ly:context-property context 'music-concert-pitch)) ; music is in concert-pitch t/f
-              (pcp (ly:context-property context 'print-concert-pitch)) ; print it in concert-pitch t/f
-              (transp (ly:context-property context 'instrumentTransposition)) ; instrument transposition
-              (keysig (ly:context-property context 'keyAlterations)) ; key-signature
-              (tonic (ly:context-property context 'tonic))) ; key-signature tonic
-
-         (define (do-transp m)
-           (let ((ap (ly:music-property m 'auto-transpose))
-                 (tp
-                  (cond
-                   ((and mcp (not pcp) (ly:pitch? transp))
-                    (ly:pitch-diff base transp))
-                   ((and (not mcp) pcp (ly:pitch? transp))
-                    transp)
-                   (else #f)))
-                 )
-             (if (ly:pitch? tp)
-                 (cond
-                  ((and (ly:pitch? ap)(not (equal? ap tp)))
-                   (ly:music-transpose m (ly:pitch-diff tp ap)))
-                  ((not (ly:pitch? ap))
-                   (ly:music-transpose m tp))
-                  )
-                 (if (ly:pitch? ap)
-                     (begin
-                     (ly:music-transpose m (ly:pitch-diff base tp))
-                     ))) ; TODO
-             (ly:music-set-property! m 'auto-transpose tp)
-             ))
-
-         ; TODO: if instrument transposition changed, produce key signature
-         (if (not (equal? transp lasttransp))
-             (let ((key-sig (make-music 'KeyChangeEvent 'pitch-alist keysig 'tonic tonic)))
-               (ly:message "is there a key signature in measure ~A? Transposition changed!" (ly:context-property context 'currentBarNumber))
-               ;(ly:broadcast (ly:context-event-source context)
-               ;  (ly:make-stream-event 'key-change-event `((music-cause . ,key-sig)) ))
-               ))
-         (set! lasttransp transp)
-
-         ; execute transposition
-         (do-transp music)
-         ))
-
-     ; create engraver
-     (make-engraver
-      (listeners
-       ; transpose note-event
-       ((note-event engraver event)
-        (cond-transp engraver (ly:event-property event 'music-cause)))
-       ; transpose key-signature
-       ((key-change-event engraver event)
-        (cond-transp engraver (ly:event-property event 'music-cause)))
-       )
-      )
-     ))
+   ; create engraver
+   (make-engraver
+    (listeners
+     ; transpose note-event
+     ((note-event engraver event)
+      (cond-transp context (ly:event-property event 'music-cause)))
+     ; transpose key-signature
+     ((key-change-event engraver event)
+      (cond-transp context (ly:event-property event 'music-cause)))
+     )
+    )
+   )
 
 autoTranspose = \with {
   % we have to ensure, the key-engraver acts after transposition is done
   \remove "Key_engraver"
   \consists \autoTransposeEngraver
+  \consists \autoKeysigEngraver
   \consists "Key_engraver"
   % if music and print are equal, do nothing
   % else transpose according to transp (up or down)

--- a/pitch/auto-transpose/module.ily
+++ b/pitch/auto-transpose/module.ily
@@ -1,12 +1,12 @@
-\version "2.19.7"
+\version "2.24.0"
 
 \header {
   snippet-title = "auto-transpose"
   snippet-author = "Jan-Peter Voigt, Saul James Tobin"
   snippet-description = \markup {
     \wordwrap {
-      This engraver transposes music accordingly to 'instrumentTransposition'
-      and 'music-concert-pitch' plus 'print-concert-pitch'.
+      This engraver transposes music according to 'instrumentTransposition'
+      and 'transpositionDirection' and prints key signatures whenever the transposition changes.
       The example is working from concert-pitch to instrument-pitch, but MIDI is not right in the other direction. (TODO)
     }
   }
@@ -30,23 +30,23 @@
    (set! all-translation-properties (cons symbol all-translation-properties))
    symbol)
 % add context properties descriptions
-%   music-concert-pitch
-%   print-concert-pitch
-#(translator-property-description 'music-concert-pitch boolean? "music is in concert pitch")
-#(translator-property-description 'print-concert-pitch boolean? "print it in concert pitch")
+%   transpose-direction
+#(translator-property-description 
+  'transposeDirection boolean-or-symbol? 
+  "Auto-transpose setting. Valid options are 'concert-to-pitch (default – concert pitch input, transposed output), 'pitch-to-concert (transposed input, concert pitch output), and #f to disable autotranspose.")
 
 #(define (which-transp context transp)
-   (let ((base (ly:make-pitch 0 0 0)) ; pitch c'
-          (mcp (ly:context-property context 'music-concert-pitch)) ; music is in concert-pitch t/f
-          (pcp (ly:context-property context 'print-concert-pitch)) ; print it in concert-pitch t/f
-          )
+   (let ((transpose-direction (ly:context-property context 'transposeDirection 'concert-to-pitch)))
      (cond
-      ((and mcp (not pcp) (ly:pitch? transp))
-       (ly:pitch-diff base transp))
-      ((and (not mcp) pcp (ly:pitch? transp))
-       transp)
+      ((and (equal? transpose-direction 'concert-to-pitch) (ly:pitch? transp))
+       (ly:pitch-diff (ly:make-pitch 0 0 0) transp)) ; invert around middle c' for opposite semantics of Lilypond's default
+      ((and (equal? transpose-direction 'pitch-to-concert) (ly:pitch? transp))
+       transp) ; keep transposition as-is for semantics that match Lilypond's default
       (else #f))))
 
+%  To Do: currently cond-transp is used for keysigs, but there are builtin scheme functions to transpose pitches and keysig alists.
+%  Maybe using them could avoid the need for complete-keysig and order-keysig helpers?
+%  Also cond-transp should return the transposed music expression.
 #(define (cond-transp context music)
    (let ((transp (ly:context-property context 'instrumentTransposition))
          (base (ly:make-pitch 0 0 0)))
@@ -76,9 +76,20 @@
          (update (lambda (el sig) (assoc-set! sig (car el) (cdr el)))))
      (fold update (copy-tree cmaj) alterations)))
 
-autoKeysigEngraver =
+#(define (order-keysig context pitch-alist)
+   (let ((order (ly:context-property context 'keyAlterationOrder)))
+     (filter
+      (lambda (alt)
+        (any (lambda (el)
+               (equal? el alt))
+          pitch-alist))
+      order)))
+
+autoTransposeEngraver = 
 #(lambda (context)
-   (let ((lasttransp (ly:context-property context 'instrumentTransposition)))
+   (let ((lasttransp (ly:context-property context 'instrumentTransposition))
+         (event-cache #f))
+     
      (define (insert-key)
        (let* ((keysig (complete-keysig (ly:context-property context 'keyAlterations)))
               (tonic (ly:context-property context 'tonic))
@@ -99,52 +110,72 @@ autoKeysigEngraver =
                      (ly:message "Transposition changed. Inserting key signature in measure ~A."
                        (ly:context-property context 'currentBarNumber))
                      (ly:event-set-property! key-event 'music-cause new-key)
+                     (ly:event-set-property! key-event 'pitch-alist 
+                       (order-keysig context (ly:event-property key-event 'pitch-alist))) ; Fixing the order might not be needed here
                      (ly:broadcast (ly:context-event-source context) key-event)
                      )))
              (set! lasttransp transp))))
-     (define (already-key)
-       (let ((transp (ly:context-property context 'instrumentTransposition)))
-         (if (not (equal? transp lasttransp))
-             (set! lasttransp transp))))
+     
+     
      (make-engraver
       (listeners
-       ((note-event engraver event)
-        (insert-key))
        ((rest-event engraver event)
-        (insert-key))
+        ;if transposition changed, broadcast a key change event, then reset lasttransp
+        (insert-key)
+        )
+       
+       ((note-event engraver event)
+        ;if transposition changed, broadcast a key change event, then reset lasttransp
+        (insert-key)
+        ;transpose the note
+        (cond-transp context (ly:event-property event 'music-cause))
+        )
+       
        ((key-change-event engraver event)
-        (already-key))
+        ; if no event already cached, or if 'autotranspose is not set, cache the event:
+        ; always register explicit key changes, 
+        ; but only register automatic keysig if there is no conflicting event
+        (if (not (ly:stream-event? event-cache))
+            (set! event-cache event)
+            (if (not (ly:event-property event 'auto-transpose #f))
+                (set! event-cache event)))
+        
+        ; if transposition changed, reset lasttransp 
+        ; (to suppress auto keysig when an explicit key change is already present)
+        (let ((transp (ly:context-property context 'instrumentTransposition)))
+         (if (not (equal? transp lasttransp))
+             (set! lasttransp transp)))
+        )
        )
-      )
-     )
-   )
-
-% engraver to automatically transpose music
-autoTransposeEngraver =
-#(lambda (context)
-   ; create engraver
-   (make-engraver
-    (listeners
-     ; transpose note-event
-     ((note-event engraver event)
-      (cond-transp context (ly:event-property event 'music-cause)))
-     ; transpose key-signature
-     ((key-change-event engraver event)
-      (cond-transp context (ly:event-property event 'music-cause)))
-     )
-    )
-   )
+      
+      ((pre-process-music engraver)
+       ; if an event is cached, transpose the tonic and pitch-alist, then set context properties
+       (if (ly:stream-event? event-cache)
+           (let ((key-music (ly:event-property event-cache 'music-cause)))
+             (cond-transp context key-music)
+             (let* ((full-alts (ly:music-property key-music 'pitch-alist))
+                    ; discard all the naturals
+                    (alts (filter
+                           (lambda (alt) (not (equal? 0 (cdr alt))))
+                           full-alts))
+                    ; fix the order of alterations
+                    (proper-alts (order-keysig context alts)))
+               ; Key_engraver reads from context properties NOT from the event itself when printing a keysig
+               ; So we can wait for all events to be heard, then fix the keysig to reflect the transposition
+               ; even if the key change was heard before the transposition change.
+               (ly:context-set-property! context 'keyAlterations proper-alts)
+               (ly:context-set-property! context 'tonic (ly:music-property key-music 'tonic)))))
+       )
+      
+      ((stop-translation-timestep engraver)
+        ;unset the event cache
+        (set! event-cache #f)
+       )
+      )))
 
 autoTranspose = \with {
-  % we have to ensure, the key-engraver acts after transposition is done
-  \remove "Key_engraver"
   \consists \autoTransposeEngraver
-  \consists \autoKeysigEngraver
-  \consists "Key_engraver"
-  % if music and print are equal, do nothing
-  % else transpose according to transp (up or down)
-  music-concert-pitch = ##t
-  print-concert-pitch = ##f
+  transposeDirection = #'concert-to-pitch
   % TODO: if music is given in instrument-pitch, but shall be printed in concert-pitch,
   %   midi pitch is false - instrumentTransposition should be "turned off" for midi(?)
 }

--- a/pitch/auto-transpose/module.ily
+++ b/pitch/auto-transpose/module.ily
@@ -31,7 +31,10 @@
    symbol)
 % add context properties descriptions
 
-#(translator-property-description 'insertKeySignatures boolean? "When #t (default) autotranspose will insert key signatures. Set to #f to turn off key signature inserts.")
+#(translator-property-description 
+  'autoInsertKeySignatures boolean? 
+  "When #t (default) autotranspose will insert key signatures. Set to #f to turn off key signature inserts.")
+
 #(translator-property-description 
   'transposeDirection boolean-or-symbol? 
   "Auto-transpose setting. Valid options are 'concert-to-pitch (default – concert pitch input, transposed output), 'pitch-to-concert (transposed input, concert pitch output), and #f to disable autotranspose.")
@@ -92,7 +95,7 @@ autoTransposeEngraver =
          (event-cache #f))
      
      (define (insert-key)
-       (if (ly:context-property context 'insertKeySignatures #t)
+       (if (ly:context-property context 'autoInsertKeySignatures #t)
            (let* ((keysig (complete-keysig (ly:context-property context 'keyAlterations)))
                   (tonic (ly:context-property context 'tonic))
                   (transp (ly:context-property context 'instrumentTransposition))

--- a/pitch/usage/auto-transpose-1.ly
+++ b/pitch/usage/auto-transpose-1.ly
@@ -1,4 +1,4 @@
-\version "2.20.0"
+\version "2.24.0"
 
 \include "deutsch.ly"
 

--- a/pitch/usage/auto-transpose-1.ly
+++ b/pitch/usage/auto-transpose-1.ly
@@ -1,4 +1,4 @@
-\version "2.19.15"
+\version "2.20.0"
 
 \include "deutsch.ly"
 
@@ -26,6 +26,15 @@ bach = \relative c'' { b a c h }
      (clefPosition . -2)
      (instrumentCueName . "Kl")
      (midiInstrument . "clarinet"))
+  
+\addInstrumentDefinition #"bass clarinet"
+  #`((instrumentTransposition . ,(ly:make-pitch -2 6 -1/2))
+     (shortInstrumentName . "Kl")
+     (clefGlyph . "clefs.G")
+     (middleCPosition . -6)
+     (clefPosition . -2)
+     (instrumentCueName . "Bass-Kl")
+     (midiInstrument . "bass clarinet"))
 
 %%% create demo score
 \score {
@@ -35,10 +44,10 @@ bach = \relative c'' { b a c h }
     \key f \major
     \bach
     \instrumentSwitch "b-clarinet"
-    \key f \major
+    \bach
+    \instrumentSwitch "bass clarinet"
     \bach
     \instrumentSwitch "eb-clarinet"
-    \key f \major
     \bach
   }
   \layout {}

--- a/pitch/usage/auto-transpose-2.ly
+++ b/pitch/usage/auto-transpose-2.ly
@@ -1,4 +1,4 @@
-\version "2.23.80"
+\version "2.24.0"
 \include "deutsch.ly"
 
 \include "oll-core/package.ily"

--- a/pitch/usage/auto-transpose-2.ly
+++ b/pitch/usage/auto-transpose-2.ly
@@ -28,7 +28,7 @@ bach = \relative c'' { b a c h }
      (midiInstrument . "clarinet"))
 
 \addInstrumentDefinition #"concert-pitch"
-  #`((instrumentTransposition . #f)
+  #`((instrumentTransposition . ,(ly:make-pitch 0 0 0))
      (shortInstrumentName . "C")
      (clefGlyph . "clefs.G")
      (middleCPosition . -6)
@@ -45,21 +45,19 @@ bach = \relative c'' { b a c h }
 \editionMod transp 5 0/4 switch.instrument.Staff.A \instrumentSwitch "concert-pitch"
 
 music = {
+  \key f \major
   \repeat unfold 3 \bach
   <>_\markup \tiny "repeat unfold c''"
   \repeat unfold 4 c''4
   <>_\markup \tiny "repeat unfold d''"
   \repeat unfold 4 d''
 }
-global = { \key f \major s1 \key f \major s1 \key f \major s1 }
+
 \score {
   \new Staff \with {
     \autoTranspose
     \editionID ##f switch.instrument
-  } \new Voice <<
-    \global
-    \music
-  >>
+  } \new Voice \music
   \layout {}
   \midi { \tempo 4=150 }
 }

--- a/pitch/usage/auto-transpose-2.ly
+++ b/pitch/usage/auto-transpose-2.ly
@@ -8,7 +8,7 @@
 % some music to insert into example
 bach = \relative c'' { b a c h }
 
-% add two transposing instrument-definitions
+% add transposing instrument-definitions
 \addInstrumentDefinition #"eb-clarinet"
   #`((instrumentTransposition . ,(ly:make-pitch 0 2 -1/2))
      (shortInstrumentName . "Es-Kl")

--- a/pitch/usage/auto-transpose-keys-1.ly
+++ b/pitch/usage/auto-transpose-keys-1.ly
@@ -1,0 +1,33 @@
+\version "2.24.0"
+
+\include "english.ly"
+
+\include "oll-core/package.ily"
+\loadModule oll-misc.pitch.auto-transpose
+
+%%% create demo score
+\score {
+  \new Staff \with {
+    \autoTranspose
+  } \relative c'' {
+    \key f \major
+    r4 c2. |
+    % Key signatures inserted at transposition changes
+    \transposition bf
+    r4 c2. |
+    % Key changes are transposed
+    \key c \major
+    r4 c2. |
+    % Key change immediately after a transposition change works correctly
+    \transposition ef
+    \key f \major
+    r4 c2. |
+    % Key change immediately before a transposition change triggers a warning and output is incorrect
+    \key bf \major
+    \transposition c'
+    \textMark "Incorrect key!"
+    r4 c2. |
+  }
+  \layout {}
+  \midi { \tempo 4=150 }
+}

--- a/pitch/usage/auto-transpose-keys-1.ly
+++ b/pitch/usage/auto-transpose-keys-1.ly
@@ -16,16 +16,15 @@
     \transposition bf
     r4 c2. |
     % Key changes are transposed
-    \key c \major
+    \key a \major
     r4 c2. |
     % Key change immediately after a transposition change works correctly
     \transposition ef
     \key f \major
     r4 c2. |
-    % Key change immediately before a transposition change triggers a warning and output is incorrect
+    % Key change immediately before a transposition change outputs correctly, but triggers a warning
     \key bf \major
-    \transposition c'
-    \textMark "Incorrect key!"
+    \transposition f
     r4 c2. |
   }
   \layout {}

--- a/pitch/usage/auto-transpose-keys-2.ly
+++ b/pitch/usage/auto-transpose-keys-2.ly
@@ -1,0 +1,91 @@
+\version "2.20.0"
+
+\include "english.ly"
+
+\include "oll-core/package.ily"
+\loadModule oll-misc.pitch.auto-transpose
+
+tenor-sax = {
+  \transposition bf,
+  <>^\markup\bold "T. Sax."
+}
+
+alto-sax = {
+  \transposition ef
+  <>^\markup\bold "A. Sax."
+}
+
+global = {
+  s1
+  \key f \major
+  s1
+}
+
+music = \relative c' {
+  \tenor-sax
+  r4 c2.
+  \alto-sax
+  r4 c2.
+}
+
+\markup \column { 
+  "Simultaneous key changes and transposition changes will trigger a warning and incorrect key signatures."
+  \vspace #1
+}
+
+%%% create demo score
+\score {
+  <<
+    \new Staff \with {
+      instrumentName = "Incorrect"
+    } << \global \music >>
+    \new Staff \with {
+      instrumentName = "Incorrect"
+    } << \music \global >>
+  >>
+  \layout {
+    \context {
+      \Staff
+      \autoTranspose
+    }
+  }
+  \midi { \tempo 4=150 }
+}
+
+global = {
+  s1
+  \key f \major
+  s1
+}
+
+music = \relative c' {
+  \tenor-sax
+  r4 c2.
+  \alto-sax
+  \key f \major
+  r4 c2.
+}
+
+\markup \column {
+  \wordwrap-string "When transposition changes at the same moment as a key change, add an extra \key command after the transposition change, and be careful about the order variables are referenced. A warning will still be triggered."
+  \vspace #1
+}
+
+%%% create demo score
+\score {
+  <<
+    \new Staff \with {
+      instrumentName = "Incorrect"
+    } << \global \music >>
+    \new Staff \with {
+      instrumentName = "Correct"
+    } << \music \global >>
+  >>
+  \layout {
+    \context {
+      \Staff
+      \autoTranspose
+    }
+  }
+  \midi { \tempo 4=150 }
+}

--- a/pitch/usage/auto-transpose-keys-2.ly
+++ b/pitch/usage/auto-transpose-keys-2.ly
@@ -1,4 +1,4 @@
-\version "2.20.0"
+\version "2.24.0"
 
 \include "english.ly"
 
@@ -16,6 +16,7 @@ alto-sax = {
 }
 
 global = {
+  \key c \major
   s1
   \key f \major
   s1
@@ -25,61 +26,14 @@ music = \relative c' {
   \tenor-sax
   r4 c2.
   \alto-sax
-  r4 c2.
+  r4 ef2.
 }
 
-\markup \column { 
-  "Simultaneous key changes and transposition changes will trigger a warning and incorrect key signatures."
-  \vspace #1
-}
-
-%%% create demo score
+%%% Simultaneous transposition and key changes output correctly regardless of order, but will trigger a warning
 \score {
   <<
-    \new Staff \with {
-      instrumentName = "Incorrect"
-    } << \global \music >>
-    \new Staff \with {
-      instrumentName = "Incorrect"
-    } << \music \global >>
-  >>
-  \layout {
-    \context {
-      \Staff
-      \autoTranspose
-    }
-  }
-  \midi { \tempo 4=150 }
-}
-
-global = {
-  s1
-  \key f \major
-  s1
-}
-
-music = \relative c' {
-  \tenor-sax
-  r4 c2.
-  \alto-sax
-  \key f \major
-  r4 c2.
-}
-
-\markup \column {
-  \wordwrap-string "When transposition changes at the same moment as a key change, add an extra \key command after the transposition change, and be careful about the order variables are referenced. A warning will still be triggered."
-  \vspace #1
-}
-
-%%% create demo score
-\score {
-  <<
-    \new Staff \with {
-      instrumentName = "Incorrect"
-    } << \global \music >>
-    \new Staff \with {
-      instrumentName = "Correct"
-    } << \music \global >>
+    \new Staff << \global \music >>
+    \new Staff << \music \global >>
   >>
   \layout {
     \context {


### PR DESCRIPTION
When a transposition change and key change occur at the same moment, correct output depends on the order events are broadcast, which is a bit annoying, but I don't see a way to handle it better.