### PR TITLE
Auto-transpose bug fixes

### DIFF
--- a/pitch/auto-transpose/module.ily
+++ b/pitch/auto-transpose/module.ily
@@ -14,6 +14,8 @@
   status = "unknown"
 }
 
+#(use-modules (ice-9 copy-tree))
+
 % taken from "scm/define-context-properties.scm"
 #(define (translator-property-description symbol type? description)
    (if (not (and

--- a/pitch/auto-transpose/module.ily
+++ b/pitch/auto-transpose/module.ily
@@ -23,7 +23,7 @@
        (throw 'init-format-error))
 
    (if (not (equal? #f (object-property symbol 'translation-doc)))
-       (ly:error (_ "symbol ~S redefined" symbol)))
+       (ly:error (G_ "symbol ~S redefined" symbol)))
 
    (set-object-property! symbol 'translation-type? type?)
    (set-object-property! symbol 'translation-doc description)
@@ -126,7 +126,12 @@ autoTransposeEngraver =
      
      (make-engraver
       (listeners
-       ((rest-event engraver event)
+       ((general-rest-event engraver event)
+        ;if transposition changed, broadcast a key change event, then reset lasttransp
+        (insert-key)
+        )
+       
+       ((skip-event engraver event)
         ;if transposition changed, broadcast a key change event, then reset lasttransp
         (insert-key)
         )

--- a/pitch/auto-transpose/module.ily
+++ b/pitch/auto-transpose/module.ily
@@ -25,7 +25,7 @@
        (throw 'init-format-error))
 
    (if (not (equal? #f (object-property symbol 'translation-doc)))
-       (ly:error (G_ "symbol ~S redefined" symbol)))
+       (ly:error (G_ "symbol ~S redefined") symbol))
 
    (set-object-property! symbol 'translation-type? type?)
    (set-object-property! symbol 'translation-doc description)


### PR DESCRIPTION
Two bug fixes:
* Allow auto-transpose to print key sigs when only skips are present
* Fix `translator-property-description` copied from Lilypond codebase to be compatible with 2.25.18.